### PR TITLE
Fix sneaky typo in cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-console_error_panic_hook = "=0.1.5"
+console_error_panic_hook = "0.1.5"
 js-sys = "0.3.19"
 lazy_static = "1.3.0"
 nalgebra = "0.18.0"


### PR DESCRIPTION
I wound up catching this extra "="-symbol as I was debugging why one of my Rust extensions kept dying on me in this project alone...

Turns out, it didn't much like to be surprised when parsing version numbers!

Hopefully this wasn't some sweet Rust trick that I just didn't know about, but indeed a genuine typo caught.

All the best!